### PR TITLE
fix #57: api breaking renaming of setMaterial method

### DIFF
--- a/core/styling.py
+++ b/core/styling.py
@@ -36,7 +36,11 @@ class Copy2dStyling:
         material = create_material(vectorlayer.renderer().symbol().color())
 
         symbol = QgsPolygon3DSymbol()
-        symbol.setMaterial(material)
+        # setMaterial method renamed to setMaterialSettings in QGIS 3.30 and is API breaking
+        try:
+            symbol.setMaterial(material)
+        except AttributeError:
+            symbol.setMaterialSettings(material)
         symbol.setEdgesEnabled(True)
 
         renderer = QgsVectorLayer3DRenderer()
@@ -64,7 +68,11 @@ class SemanticSurfacesStyling:
             material = create_material(colors["diffuse"], colors["ambient"], colors["specular"])
 
             symbol = QgsPolygon3DSymbol()
-            symbol.setMaterial(material)
+            # setMaterial method renamed to setMaterialSettings in QGIS 3.30 and is API breaking
+            try:
+                symbol.setMaterial(material)
+            except AttributeError:
+                symbol.setMaterialSettings(material)
             symbol.setEdgesEnabled(True)
 
             new_rule = QgsRuleBased3DRenderer.Rule(symbol, "\"surface.type\" = '{surface}'".format(surface=surface_type))
@@ -76,7 +84,11 @@ class SemanticSurfacesStyling:
             material = create_material(self._else_color)
 
         symbol = QgsPolygon3DSymbol()
-        symbol.setMaterial(material)
+        # setMaterial method renamed to setMaterialSettings in QGIS 3.30 and is API breaking
+        try:
+            symbol.setMaterial(material)
+        except AttributeError:
+            symbol.setMaterialSettings(material)
         symbol.setEdgesEnabled(True)
 
         new_rule = QgsRuleBased3DRenderer.Rule(symbol, "ELSE")


### PR DESCRIPTION
Like stated in #57, the setMaterial() method of QgsPolygon3DSymbol is renamed in QGIS 3.30 to setMaterialSettings().
Unfortunately, this is API breaking. setMaterial() works right now only until QGIS 3.28; setMaterialSettings() only from 3.30 on.
It's not a nice fix, using both methods in a try except block. But now the plugin should work with all QGIS versions.